### PR TITLE
fix(ai-providers): allow typing in model discovery search

### DIFF
--- a/src/components/ui/sheet/Sheet.vue
+++ b/src/components/ui/sheet/Sheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <DialogRoot :open="isOpen" @update:open="handleOpenChange">
+  <DialogRoot :open="isOpen" :modal="props.modal" @update:open="handleOpenChange">
     <DialogPortal>
       <!-- 背景遮罩 -->
       <DialogOverlay 
@@ -89,7 +89,7 @@ import {
 import { X } from 'lucide-vue-next'
 
 // Props 定义
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   open?: boolean
   modelValue?: boolean
   size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | 'full'
@@ -98,7 +98,10 @@ const props = defineProps<{
   icon?: Component
   iconClass?: string
   noPadding?: boolean
-}>()
+  modal?: boolean
+}>(), {
+  modal: true
+})
 
 // Emits 定义
 const emit = defineEmits<{

--- a/src/views/AiProvidersPage.vue
+++ b/src/views/AiProvidersPage.vue
@@ -594,6 +594,7 @@
     <Sheet 
       :open="modalOpen && modalType === 'openai'" 
       @update:open="closeModal" 
+      :modal="!modelDiscoveryDialog.open"
       size="3xl" 
       :title="`${isEditing ? '编辑' : '添加'} OpenAI 提供商`" 
       description="添加兼容 OpenAI 接口的第三方服务商，支持模型映射和自动发现。"


### PR DESCRIPTION
## Summary
- Fix nested modal focus trap so the OpenAI model discovery dialog search input is editable.
- Add a Sheet prop "modal" and disable Sheet modal mode while the discovery dialog is open.

## Test Plan
- npm run type-check
- npm run test:run
- Manual: AI Providers -> OpenAI Compat -> Add Provider -> Get Models -> Search model
